### PR TITLE
Update the AGP to version 8.13.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.13.0"
+agp = "8.13.1"
 annotationJvm = "1.9.1"
 appcompat = "1.7.1"
 constraintlayout = "2.2.1"


### PR DESCRIPTION
### Update AGP Version
 - Update the Android Gradle Plugin (AGP) to version 8.13.1